### PR TITLE
Set response headers for Web app request

### DIFF
--- a/examples/go-api/main.go
+++ b/examples/go-api/main.go
@@ -68,5 +68,8 @@ func PingHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func SecuredPingHandler(w http.ResponseWriter, r *http.Request) {
+	allowHeaders := r.Header.Get("Access-Control-Request-Headers")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Headers", allowHeaders)
 	respondJson("All good. You only get this message if you're authenticated", w)
 }


### PR DESCRIPTION
As described in https://github.com/auth0/auth0-react/issues/15, if we were to run the examples locally (i.e. localhost) using the seed projects provided by auth0, the backend does not handle requests through the browser correctly since it does a CORS preflight [1] which the secured endpoint fails to handle correctly.

[1] http://stackoverflow.com/questions/32500073/request-header-field-access-control-allow-headers-is-not-allowed-by-itself-in-pr

