### PR TITLE
Fix compile error use ManagerConfig instead of string

### DIFF
--- a/examples/regular-web-app/app/app.go
+++ b/examples/regular-web-app/app/app.go
@@ -9,6 +9,9 @@ var (
 )
 
 func Init() {
-	GlobalSessions, _ = session.NewManager("memory", `{"cookieName":"gosessionid","gclifetime":3600}`)
+	GlobalSessions, _ = session.NewManager("memory", &session.ManagerConfig{
+		CookieName: "gosessionid",
+		Gclifetime: 3600,
+	})
 	go GlobalSessions.GC()
 }


### PR DESCRIPTION
now beego, use `ManagerConfig` instead of string.

see  https://github.com/astaxie/beego/commit/ef0d3d80dcef374f61202f7b045d56e307b66d30